### PR TITLE
Inline Compose environment configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Changed
+- Inlined Docker Compose environment configuration so the stack runs without a `.env` file.
+
 ## [0.1.0] - 2025-02-14
 ### Added
 - Initial implementation of the MCP human handoff server with Flask UI and in-memory TTL question storage.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ mcp-server/
 
 ## Configuration
 
-Set the following environment variables (use a `.env` file locally):
+Set the following environment variables. When using Docker Compose, these defaults are
+defined inline, but you can override them or provide a `.env` file for local development:
 
 | Variable | Description | Default |
 | --- | --- | --- |
@@ -113,7 +114,9 @@ docker compose up --build
 ```
 
 This launches the MCP transport alongside the Flask UI in a single container. Expose the HTTP
-endpoints internally or terminate TLS at an upstream proxy for production deployments.
+endpoints internally or terminate TLS at an upstream proxy for production deployments. The Compose
+file now ships with sensible defaults for every runtime variable, so you can start the stack without
+maintaining a separate `.env` file.
 
 ## MCP Workflow Summary
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,13 @@ services:
       SERVER_URL: "http://localhost:8000"
       MCP_API_KEY: "change-me"
       MCP_TRANSPORT: "streamable-http"
-    env_file:
-      - .env
+      FLASK_HOST: "0.0.0.0"
+      FLASK_PORT: "8000"
+      MCP_HOST: "0.0.0.0"
+      MCP_PORT: "8765"
+      QUESTION_TTL_SECONDS: "300"
+      POLL_INTERVAL_SECONDS: "30"
+      FALLBACK_ANSWER: "Sorry, no human could be reached. Please use your best judgment."
+      PUSHOVER_TOKEN: ""
+      PUSHOVER_USER: ""
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- inline all runtime environment variables for the `mcp-server` service so Docker Compose no longer depends on a `.env` file
- document the inline defaults in the README and changelog so operators know the Compose stack works out-of-the-box

## Testing
- ruff check .
- pytest
- docker compose config *(fails: docker not installed in environment)*
- docker compose up -d *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd91972f4832aaabd5e73aee28b28