### PR TITLE
Add explicit utility package initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 - Inlined Docker Compose environment configuration so the stack runs without a `.env` file.
+- Added an explicit `server.utility` package initializer to guarantee direct imports succeed.
 
 ## [0.1.0] - 2025-02-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ mcp-server/
     └── test_utility.py
 ```
 
+The explicit `server/utility/__init__.py` ensures the module can be imported directly, e.g.
+`from server.utility.config import get_config`.
+
 ## Configuration
 
 Set the following environment variables. When using Docker Compose, these defaults are

--- a/server/utility/__init__.py
+++ b/server/utility/__init__.py
@@ -1,0 +1,7 @@
+"""Utility helpers shared across the MCP server implementation."""
+
+__all__ = [
+    "config",
+    "context_manager",
+    "pushover",
+]


### PR DESCRIPTION
## Summary
- add an explicit `server.utility` package initializer so imports like `from server.utility.config` work reliably
- document the package availability in the README and changelog

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cddc9222f8832a828977610b71183c