### PR TITLE
Limit Docker publish workflow to main/dev branch tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Build and Publish Docker Image
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  push:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+jobs:
+  docker:
+    name: Build image and publish to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (pull request validation)
+        if: github.event_name == 'pull_request'
+        run: docker build --tag mcp-server-test:${{ github.sha }} .
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        if: github.event_name != 'pull_request'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_REPOSITORY }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+
+      - name: Build and push Docker image
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- GitHub Actions workflow that builds the Docker image and publishes it to Docker Hub.
 ### Changed
 - Inlined Docker Compose environment configuration so the stack runs without a `.env` file.
 - Added an explicit `server.utility` package initializer to guarantee direct imports succeed.
+- Updated the Docker publishing workflow to build on `main`/`dev` only and tag images with the
+  branch name instead of a rolling `latest` tag.
 
 ## [0.1.0] - 2025-02-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -121,6 +121,28 @@ endpoints internally or terminate TLS at an upstream proxy for production deploy
 file now ships with sensible defaults for every runtime variable, so you can start the stack without
 maintaining a separate `.env` file.
 
+## Docker Image Publishing
+
+GitHub Actions automation in [`.github/workflows/docker-publish.yml`](.github/workflows/docker-publish.yml)
+builds the project image and, when appropriate, pushes it to Docker Hub. The workflow:
+
+* Runs on pull requests targeting `main` or `dev` to ensure Docker changes build cleanly.
+* Publishes images for pushes to the `main` and `dev` branches.
+* Tags each published image with the branch name (for example, `main` or `dev`) and the commit SHA—no
+  rolling `latest` tag is produced.
+
+To enable publishing, configure the following repository secrets with your Docker Hub credentials:
+
+| Secret | Purpose |
+| --- | --- |
+| `DOCKERHUB_USERNAME` | Docker Hub username or organization name. |
+| `DOCKERHUB_TOKEN` | Access token or password with permission to push images. |
+| `DOCKERHUB_REPOSITORY` | Target repository in `username/image` format. |
+
+After the secrets are set, pushes to `main` or `dev` automatically update the Docker Hub image. You
+can also trigger the workflow manually from the GitHub Actions tab to produce ad-hoc builds from
+either branch.
+
 ## MCP Workflow Summary
 
 1. **Agent calls `ask_question`** – The tool generates a `question_id` and `auth_key`, stores the


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Docker image, validates pull requests, and publishes to Docker Hub on pushes or manual triggers
- document the publishing workflow and required Docker Hub secrets in the README
- record the automation addition in the changelog
- adjust the workflow to run only for the `main` and `dev` branches, publish branch-name tags instead of `latest`, and update the docs/changelog accordingly

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cddda8588c832a9867da560d83def2